### PR TITLE
Remove usage of the `stdsimd` feature

### DIFF
--- a/crates/uuid-simd/src/lib.rs
+++ b/crates/uuid-simd/src/lib.rs
@@ -17,7 +17,6 @@
 #![doc=vsimd::shared_docs!()]
 //
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
-#![cfg_attr(feature = "unstable", feature(stdsimd))]
 #![cfg_attr(feature = "unstable", feature(arm_target_feature))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(test, deny(warnings))]

--- a/crates/vsimd/src/lib.rs
+++ b/crates/vsimd/src/lib.rs
@@ -2,7 +2,6 @@
 #![cfg_attr(not(any(test, feature = "std")), no_std)]
 #![cfg_attr(
     feature = "unstable",
-    feature(stdsimd),
     feature(arm_target_feature),
     feature(portable_simd),
     feature(inline_const),


### PR DESCRIPTION
This feature is removed from the Nightly and should be removed as well from this crate.