### PR TITLE
Remove redundant imports

### DIFF
--- a/crates/base32-simd/src/heap.rs
+++ b/crates/base32-simd/src/heap.rs
@@ -4,8 +4,11 @@ use crate::{AppendBase32Decode, AppendBase32Encode, Base32, Error, FromBase32Dec
 
 use vsimd::tools::{alloc_uninit_bytes, assume_init, boxed_str, slice_parts};
 
+#[cfg(not(any(test, feature = "std")))]
 use alloc::boxed::Box;
+#[cfg(not(any(test, feature = "std")))]
 use alloc::string::String;
+#[cfg(not(any(test, feature = "std")))]
 use alloc::vec::Vec;
 
 #[inline]

--- a/crates/base32-simd/src/lib.rs
+++ b/crates/base32-simd/src/lib.rs
@@ -70,7 +70,7 @@ use crate::encode::encoded_length_unchecked;
 
 use vsimd::tools::{slice_mut, slice_parts};
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", not(any(test, feature = "std"))))]
 use alloc::{string::String, vec::Vec};
 
 const BASE32_CHARSET: &[u8; 32] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";

--- a/crates/base64-simd/src/forgiving.rs
+++ b/crates/base64-simd/src/forgiving.rs
@@ -6,7 +6,7 @@ use vsimd::tools::slice_mut;
 
 use core::ptr::copy_nonoverlapping;
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", not(any(test, feature = "std"))))]
 use alloc::vec::Vec;
 
 /// Forgiving decodes a base64 string to bytes and writes inplace.

--- a/crates/base64-simd/src/heap.rs
+++ b/crates/base64-simd/src/heap.rs
@@ -6,8 +6,11 @@ use crate::{FromBase64Decode, FromBase64Encode};
 
 use vsimd::tools::{alloc_uninit_bytes, assume_init, boxed_str, slice_parts};
 
+#[cfg(not(any(test, feature = "std")))]
 use alloc::boxed::Box;
+#[cfg(not(any(test, feature = "std")))]
 use alloc::string::String;
+#[cfg(not(any(test, feature = "std")))]
 use alloc::vec::Vec;
 
 #[inline]

--- a/crates/base64-simd/src/lib.rs
+++ b/crates/base64-simd/src/lib.rs
@@ -78,7 +78,7 @@ use crate::encode::encoded_length_unchecked;
 
 use vsimd::tools::{slice_mut, slice_parts};
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", not(any(test, feature = "std"))))]
 use alloc::{string::String, vec::Vec};
 
 const STANDARD_CHARSET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";

--- a/crates/hex-simd/src/heap.rs
+++ b/crates/hex-simd/src/heap.rs
@@ -2,8 +2,11 @@ use crate::{AppendHexDecode, AppendHexEncode, AsciiCase, Error, FromHexDecode, F
 
 use vsimd::tools::{alloc_uninit_bytes, assume_init, boxed_str, slice_parts};
 
+#[cfg(not(any(test, feature = "std")))]
 use alloc::boxed::Box;
+#[cfg(not(any(test, feature = "std")))]
 use alloc::string::String;
+#[cfg(not(any(test, feature = "std")))]
 use alloc::vec::Vec;
 
 #[inline]

--- a/crates/hex-simd/src/lib.rs
+++ b/crates/hex-simd/src/lib.rs
@@ -65,7 +65,7 @@ pub use vsimd::ascii::AsciiCase;
 
 use vsimd::tools::{slice_mut, slice_parts};
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", not(any(test, feature = "std"))))]
 use alloc::{string::String, vec::Vec};
 
 /// Calculates the encoded length.


### PR DESCRIPTION
Rust 1.78 Nightly started to raise warning about duplicate imports. For instance, if `std::vec::Vec` is already imported, an attempt to import `alloc::vec::Vec` (the same type as `std::vec::Vec`) will cause a warning.

This commit gates such imports behind `not(any(test, feature = "std"))`.