### PR TITLE
Update dev-dependencies on const-str to v1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ name = "base64-simd"
 version = "0.9.0-dev"
 dependencies = [
  "base64",
- "const-str 0.6.4",
+ "const-str",
  "getrandom",
  "outref",
  "rand",
@@ -103,15 +103,9 @@ dependencies = [
 
 [[package]]
 name = "const-str"
-version = "0.6.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "451d0640545a0553814b4c646eb549343561618838e9b42495f466131fe3ad49"
-
-[[package]]
-name = "const-str"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0664d2867b4a32697dfe655557f5c3b187e9b605b38612a748e5ec99811d160"
+checksum = "18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f"
 
 [[package]]
 name = "cpufeatures"
@@ -566,7 +560,7 @@ dependencies = [
 name = "vsimd"
 version = "0.9.0-dev"
 dependencies = [
- "const-str 0.7.1",
+ "const-str",
  "getrandom",
  "rand",
  "wasm-bindgen-test",

--- a/crates/base64-simd/Cargo.toml
+++ b/crates/base64-simd/Cargo.toml
@@ -30,7 +30,7 @@ rayon = { version = "1.6.1", optional = true }
 [dev-dependencies]
 base64 = "0.22.0"
 rand = "0.10"
-const-str = "0.6"
+const-str = "1.0"
 
 [target.'cfg(target_arch="wasm32")'.dev-dependencies]
 getrandom = { version = "0.4.2", features = ["wasm_js"] }

--- a/crates/vsimd/Cargo.toml
+++ b/crates/vsimd/Cargo.toml
@@ -21,7 +21,7 @@ detect = ["std"]
 unstable = []
 
 [dev-dependencies]
-const-str = "0.7"
+const-str = "1.0"
 rand = "0.10"
 
 [target.'cfg(target_arch="wasm32")'.dev-dependencies]


### PR DESCRIPTION
`cargo test --workspace` still passes