### PR TITLE
vsimd: add missing #[inline(always)] to unified::max

### DIFF
--- a/crates/vsimd/src/unified.rs
+++ b/crates/vsimd/src/unified.rs
@@ -647,6 +647,7 @@ pub fn sub_sat<S: InstructionSet, T: POD, V: POD>(s: S, a: V, b: V) -> V {
     }
 }
 
+#[inline(always)]
 pub fn max<S: InstructionSet, T: POD, V: POD>(s: S, a: V, b: V) -> V {
     if is_pod_type!(V, V256) {
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]


### PR DESCRIPTION
`unified::max` was the only function in `unified.rs` missing `#[inline(always)]`. LLVM does not reliably inline it in downstream generic contexts.

In `unicode-simd`'s `is_utf32le` (AVX2 path), the per-32B-chunk call to `vsimd::unified::max::<AVX2, u32, V256>` was not inlined when the downstream crate is built with global `-C target-feature=+avx2`: the hot loop issues an indirect call per chunk, with the 32-byte vector args/result spilled through the stack.

Benchmark on AMD Zen 4, `unicode_simd::is_utf32le` on 64 KiB, `-C target-feature=+sse4.1,+avx2`

| before | after |
|---|---|
| 8.098 µs | 427.8 ns |